### PR TITLE
Shortened labels of documentation sources.

### DIFF
--- a/octoprint_marlingcodedocumentation/templates/marlingcodedocumentation.jinja2
+++ b/octoprint_marlingcodedocumentation/templates/marlingcodedocumentation.jinja2
@@ -78,15 +78,15 @@
     <!-- ko if: $root.showSourcesCheckboxes -->
     <label class="checkbox inline terminal-documentation-source terminal-documentation-source-marlin">
         <input type="checkbox" data-bind="checked: $root.includeSourceMarlin">
-        Include from Marlin
+        Marlin
     </label>
     <label class="checkbox inline terminal-documentation-source terminal-documentation-source-reprap">
         <input type="checkbox" data-bind="checked: $root.includeSourceRepRap">
-        Include from RepRap
+        RepRap
     </label>
     <label class="checkbox inline terminal-documentation-source terminal-documentation-source-klipper">
         <input type="checkbox" data-bind="checked: $root.includeSourceKlipper">
-        Include from Klipper
+        Klipper
     </label>
     <!-- /ko -->
     <!-- ko if: !$root.showSourcesCheckboxes() -->


### PR DESCRIPTION
This change prevents the text from flowing outside of the console box/tab without loosing the design intent.