### PR TITLE
use relative paths for API URL

### DIFF
--- a/octoprint_marlingcodedocumentation/static/js/marlingcodedocumentation.js
+++ b/octoprint_marlingcodedocumentation/static/js/marlingcodedocumentation.js
@@ -695,7 +695,7 @@ $(function() {
             self.favouriteUndo(null);
         };
         self.onUpdateDocumentation = async () => {
-            const response = await fetch("/api/plugin/marlingcodedocumentation", {
+            const response = await fetch("api/plugin/marlingcodedocumentation", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -718,7 +718,7 @@ $(function() {
             document.getElementById("settings-update_documentation_url").value = self.updateDocumentationUrlDefault();
         };
         self.refreshDocumentation = async () => {
-            const response = await fetch("/api/plugin/marlingcodedocumentation");
+            const response = await fetch("api/plugin/marlingcodedocumentation");
             if (!response.ok) {
                 return;
             }

--- a/octoprint_marlingcodedocumentation/static/js/marlingcodedocumentation.min.js
+++ b/octoprint_marlingcodedocumentation/static/js/marlingcodedocumentation.min.js
@@ -911,7 +911,7 @@ $(function () {
     };
 
     self.onUpdateDocumentation = async function () {
-      var response = await fetch("/api/plugin/marlingcodedocumentation", {
+      var response = await fetch("api/plugin/marlingcodedocumentation", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -940,7 +940,7 @@ $(function () {
     };
 
     self.refreshDocumentation = async function () {
-      var response = await fetch("/api/plugin/marlingcodedocumentation");
+      var response = await fetch("api/plugin/marlingcodedocumentation");
 
       if (!response.ok) {
         return;


### PR DESCRIPTION
When OctoPrint is using a base URL that isn't `/`, e.g. when created using [OctoPrint Deploy](https://github.com/paukstelis/octoprint_deploy), MarlinGcodeDocumentation doesn't work because it's trying to load the absolute URL `/api/plugin/marlingcodedocumentation` which doesn't exist. Using a relative path instead, without the leading `/`, appears to work fine.